### PR TITLE
Set bash interpretter and fail on errors

### DIFF
--- a/get-property.sh
+++ b/get-property.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 
 if [ ! -e .jwt ]; then
   echo "Please create the .jwt file using login.sh"

--- a/get-things.sh
+++ b/get-things.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 
 if [ ! -e .jwt ]; then
   echo "Please create the .jwt file using login.sh"

--- a/login.sh
+++ b/login.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 
 read -p    "Enter    email: " USERNAME
 read -s -p "Enter password: " PASSWORD

--- a/set-property.sh
+++ b/set-property.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 
 if [ ! -e .jwt ]; then
   echo "Please create the .jwt file using login.sh"


### PR DESCRIPTION
Bash is more safe if using advanced features,

Observed issue on ubuntu-17.10:

  ./login.sh: 4: read: Illegal option -s

Change-Id: I4701d7fb1f2b27b54095e0b1b3106b13deb00cc6
Signed-off-by: Philippe Coval <rzr@users.sf.net>